### PR TITLE
Switched roles of publish/subscribe according to openAPI 

### DIFF
--- a/example/specs/basic_queue_groups.yaml
+++ b/example/specs/basic_queue_groups.yaml
@@ -1,0 +1,58 @@
+asyncapi: 2.1.0
+info:
+  title: My_API
+  version: 1.0.0
+servers:
+  production:
+    url: demo.nats.io
+    protocol: nats
+channels:
+  user/signedup:
+    subscribe:
+      operationId: onUserSignup
+      summary: User signup notification
+      message:
+        payload:
+          type: object
+          properties:
+            userSingnedUp:
+              type: string
+            userID: 
+              type: number
+            timestamp: 
+              type: string
+    publish:
+      bindings:
+        nats:
+          queue: MyQueue
+      operationId: userSignedUp
+      summary: send welcome email to user
+      message:
+        payload: 
+          type: object
+          properties:
+            userSingnedUp:
+              type: string
+            userID: 
+              type: number
+            timestamp: 
+              type: string
+  user/buy:
+    subscribe:
+      bindings:
+        nats:
+          queue: MyQueue
+      operationId: userBought
+      summary: User bought something
+      message:
+        payload:
+          type: string
+    publish:
+      bindings:
+        nats:
+          queue: MyQueue
+      operationId: onUserBought
+      summary: send email to user
+      message:
+        payload:
+          type: string  

--- a/src/asyncapi_model/channel.rs
+++ b/src/asyncapi_model/channel.rs
@@ -109,11 +109,9 @@ pub struct Channel {
     pub servers: Vec<String>,
     /// A definition of the SUBSCRIBE operation, which defines the messages produced
     /// by the application and sent to the channel.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub subscribe: Option<Operation>,
     /// A definition of the PUBLISH operation, which defines the messages consumed
     /// by the application from the channel.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub publish: Option<Operation>,
     /// A map of the parameters included in the channel name. It SHOULD be present only
     /// when using channels with expressions (as defined by
@@ -273,7 +271,6 @@ pub struct Operation {
     pub external_docs: Option<ExternalDocumentation>,
     /// A map where the keys describe the name of the protocol and the
     /// values describe protocol-specific definitions for the operation.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub bindings: Option<ReferenceOr<OperationBinding>>,
     /// A list of traits to apply to the operation object.
     /// Traits MUST be merged into the operation object using the

--- a/src/asyncapi_model/operation_binding.rs
+++ b/src/asyncapi_model/operation_binding.rs
@@ -13,7 +13,6 @@ pub struct OperationBinding {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ws: Option<WebSocketsOperationBinding>,
     /// Protocol-specific information for a Kafka operation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub kafka: Option<KafkaOperationBinding>,
     /// Protocol-specific information for an Anypoint MQ operation.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -31,7 +30,6 @@ pub struct OperationBinding {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub mqtt5: Option<MQTT5OperationBinding>,
     /// Protocol-specific information for a NATS operation
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub nats: Option<NATSOperationBinding>,
     /// Protocol-specific information for a JMS operation
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/templates/handler.rstmpl
+++ b/templates/handler.rstmpl
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 
 
- {{ range .subscribe_channels  }}
+ {{ range .publish_channels  }}
     {{ range (index . 1).messages }}
         {{ if .payload }}
          // payload
@@ -22,7 +22,7 @@ use serde::{Deserialize, Serialize};
     }
 {{ end  }}
 
-{{ range .publish_channels }}
+{{ range .subscribe_channels }}
     /// publish message to {{ (index . 1).unique_id }}
     ///  messages: 
     /// {{ range (index . 1).messages }}

--- a/templates/main.rstmpl
+++ b/templates/main.rstmpl
@@ -10,6 +10,7 @@ pub struct Producer {}
 async fn listen_for_message(sub: &mut Subscriber, handler: impl Fn(Message)) {
     while let Some(message) = sub.next().await {
         handler(message);
+        println!("Message received by Subscriber: {:?}", sub); 
     }
 }
 async fn publish_message(client: &Client, channel: &str, payload: &'static str) {
@@ -24,18 +25,31 @@ async fn publish_message(client: &Client, channel: &str, payload: &'static str) 
 async fn main() -> Result<(), async_nats::Error> {
     let client = async_nats::connect("{{ .server.url }}").await?;
 
-    {{ range .subscribe_channels }}
+    {{ range .publish_channels }}
+    {{ if (index . 1).original_operation.bindings }}
+        let mut {{ (index . 1).unique_id }} = client.queue_subscribe("{{ index . 0  }}".into(), "{{ (index . 1).original_operation.bindings.nats.queue }}".into()).await?;
+       
+        //Just for testing, create additional queue subscriber 
+        let mut {{ (index . 1).unique_id }}_2 = client.queue_subscribe("{{ index . 0  }}".into(), "{{ (index . 1).original_operation.bindings.nats.queue }}".into()).await?;
+
+    {{ else }}
         let mut {{ (index . 1).unique_id }} = client.subscribe("{{ index . 0  }}".into()).await?;
+    {{end}}
     {{end}}
 
     test(&client, "foo").await;
 
     tokio::join!(
-    {{ range .publish_channels }}
+    {{ range .subscribe_channels }}
         producer_{{ (index . 1).unique_id }}(&client, "{{ index . 0  }}"),
     {{ end  }}
-    {{ range .subscribe_channels  }}
+    {{ range .publish_channels  }}
         listen_for_message(&mut  {{ (index . 1).unique_id }}, handler_{{ (index . 1).unique_id }}),
+        
+        //just for testing, listen with secong queue subscriber: 
+        listen_for_message(&mut  {{ (index . 1).unique_id }}_2, handler_{{ (index . 1).unique_id }}),
+
+
     {{  end  }}
     );
 


### PR DESCRIPTION
-Added test .yaml file for queue groups 
-Deleted ["skip serializing if Option:: is_None"] from the fields needed in the template, otherwise it panics 

