### PR TITLE
Added support for a stream to Template

### DIFF
--- a/example/specs/basic_queues_and_stream.yaml
+++ b/example/specs/basic_queues_and_stream.yaml
@@ -1,0 +1,90 @@
+asyncapi: 2.1.0
+info:
+  title: My_API
+  version: 1.0.0
+servers:
+  production:
+    url: demo.nats.io
+    protocol: nats
+channels:
+  user/signedup:
+    subscribe:
+      bindings:
+        nats:
+          streamname: testStream
+      operationId: onUserSignup
+      summary: User signup notification
+      message:
+        payload:
+          type: object
+          properties:
+            userSingnedUp:
+              type: string
+            userID: 
+              type: number
+            timestamp: 
+              type: string
+    publish:
+      bindings:
+        nats:
+          streamname: testStream
+      operationId: userSignedUp
+      summary: send welcome email to user
+      message:
+        payload: 
+          type: object
+          properties:
+            userSingnedUp:
+              type: string
+            userID: 
+              type: number
+            timestamp: 
+              type: string
+  user/buy:
+    subscribe:
+      bindings:
+        nats:
+          queue: MyQueue
+      operationId: userBought
+      summary: User bought something
+      message:
+        payload:
+          type: object
+          properties:
+            userBought:
+              type: string
+    publish:
+      bindings:
+        nats:
+          queue: MyQueue
+      operationId: onUserBought
+      summary: send email to user
+      message:
+        payload:
+          type: object
+          properties:
+            userBought:
+              type: string
+  user/sell:
+    subscribe:
+      operationId: userSold
+      summary: User sold something
+      message:
+        payload:
+          type: object
+          properties:
+            soldItem:
+              type: string
+            timestamp: 
+              type: string
+    publish:
+      operationId: onUserSold
+      summary: send email to user
+      message:
+        payload:
+          type: object
+          properties:
+            soldItem:
+              type: string
+            timestamp: 
+              type: string

--- a/example/specs/test_stream.yml
+++ b/example/specs/test_stream.yml
@@ -1,0 +1,34 @@
+asyncapi: 2.1.0
+info:
+  title: My_API
+  version: 1.0.0
+servers:
+  production:
+    url: demo.nats.io
+    protocol: nats
+channels:
+  user/signedup:
+    subscribe:
+      bindings:
+        nats:
+          streamname: testStream
+      operationId: onUserSignup
+      summary: User signup notification
+      message:
+        payload:
+          type: object
+          properties:
+            userSingnedUp:
+              type: string
+    publish:
+      bindings:
+        nats:
+          streamname: testStream
+      operationId: userSignedUp
+      summary: send welcome email to user
+      message:
+        payload:
+          type: object
+          properties:
+            OnusersingnUp:
+              type: string

--- a/src/asyncapi_model/operation_binding.rs
+++ b/src/asyncapi_model/operation_binding.rs
@@ -243,11 +243,11 @@ pub struct MQTT5OperationBinding {}
 #[serde(rename_all = "camelCase")]
 pub struct NATSOperationBinding {
     /// Defines the name of the queue to use. It MUST NOT exceed 255 characters.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub queue: Option<String>,
     /// The version of this binding. If omitted, "latest" MUST be assumed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub binding_version: Option<String>,
+    pub streamname: Option<String>,
 }
 
 /// This object MUST NOT contain any properties. Its name is reserved for future use.

--- a/templates/handler.go
+++ b/templates/handler.go
@@ -1,5 +1,11 @@
-use async_nats::{Client, Message};
+use async_nats::{Client, Message, jetstream};
+use async_nats::jetstream::Context;
 use crate::{publish_message,
+{{ range .subscribe_channels }}
+{{ if (index . 1).original_operation.bindings.nats.streamname }}
+    stream_publish_message,
+{{end}}
+{{end}}
 {{ range .model.messages }}
     {{ if .payload }}
         model::{{ .payload.unique_id }},
@@ -21,6 +27,49 @@ use std::time;
     /// {{ range (index . 1).messages }}
     ///     {{ .unique_id }}
     /// {{ end }}
+    {{ if (index . 1).original_operation.bindings.nats.streamname }}
+    pub fn stream_handler_{{ (index . 1).unique_id }}(message: jetstream::Message) {
+        {{ if (index . 1).multiple_messages_enum }}
+            match serde_json::from_slice::<{{ (index . 1).multiple_messages_enum.unique_id }}>(&message.message.payload.as_ref()) {
+                Ok(deserialized_message) => {
+                    // TODO: Replace this with your own handler code
+                    println!("Received message {:#?}", deserialized_message);
+                },
+                Err(_) => {
+                    println!("Failed to deserialize message payload: {{ (index . 1).multiple_messages_enum.unique_id }}\nOriginal message: {:#?}", message);
+                    // TODO: Handle the failed deserialization here
+                },
+            }
+        {{else}}
+        {{ range (index . 1).messages }}
+        match serde_json::from_slice::<{{ .unique_id }}>(&message.message.payload.as_ref()) {
+            Ok(deserialized_message) => {
+                println!("Received message {:#?}", deserialized_message);
+                // TODO: Replace this with your own handler code
+                {{ if .payload}}
+                {{ if .payload.multiple_payload_enum}}
+                    // TODO: this is always None for now (unreachable),
+                    // take a look the comment in src/template_model/simplified_operation.rs/simplify_schema
+                    match deserialized_message.payload {
+                        {{$enumName := .payload.multiple_payload_enum.unique_id}}
+                        {{ range .payload.multiple_payload_enum.messages }}
+                            {{ $enumName }}::{{ .unique_id }}(payload) => {
+                            println!("Received message payload {{ .unique_id }}", payload);
+                            }   
+                        {{ end }}
+                    }
+                {{ end }}
+                {{ end }}
+            },
+            Err(_) => {
+                println!("Failed to deserialize message payload: {{ .unique_id }}\nOriginal message: {:#?}", message);
+                // TODO: Handle the failed deserialization here
+            },
+        }
+        {{ end }}
+        {{ end }}
+    }
+    {{else}}
     pub fn handler_{{ (index . 1).unique_id }}(message: Message) {
         {{ if (index . 1).multiple_messages_enum }}
             match serde_json::from_slice::<{{ (index . 1).multiple_messages_enum.unique_id }}>(&message.payload.as_ref()) {
@@ -62,6 +111,7 @@ use std::time;
         {{ end }}
         {{ end }}
     }
+    {{end}}
 {{ end  }}
 
 {{ range .subscribe_channels }}
@@ -70,6 +120,16 @@ use std::time;
     /// {{ range (index . 1).messages }}
     ///     {{ .unique_id }}
     /// {{ end }}
+    {{ if (index . 1).original_operation.bindings.nats.streamname }}
+    pub async fn stream_producer_{{ (index . 1).unique_id }}(context_stream: &Context, channel: &str) { //context instead of client
+        // This is just an example producer, publishing a message every 2 seconds
+        // TODO: replace this with your own producer code
+        loop {
+            tokio::time::sleep(time::Duration::from_secs(2)).await;
+            stream_publish_message(context_stream, channel, "{\"test\":\"serialized\"}").await;
+        }
+    }
+    {{else}}
     pub async fn producer_{{ (index . 1).unique_id }}(client: &Client, channel: &str) {
         // This is just an example producer, publishing a message every 2 seconds
         // TODO: replace this with your own producer code
@@ -78,6 +138,7 @@ use std::time;
             publish_message(client, channel, "{\"test\":\"serialized\"}").await;
         }
     }
+    {{end}}
 {{ end  }}
 
 

--- a/templates/handler.go
+++ b/templates/handler.go
@@ -30,49 +30,93 @@ use std::time;
     ///     {{ .unique_id }}
     /// {{ end }}
     {{ if (index . 1).original_operation.bindings }}
-    {{ if (index . 1).original_operation.bindings.nats.streamname }}
-    pub fn stream_handler_{{ (index . 1).unique_id }}(message: jetstream::Message) {
-        {{ if (index . 1).multiple_messages_enum }}
-            match serde_json::from_slice::<{{ (index . 1).multiple_messages_enum.unique_id }}>(&message.message.payload.as_ref()) {
-                Ok(deserialized_message) => {
-                    // TODO: Replace this with your own handler code
-                    println!("Received message {:#?}", deserialized_message);
-                },
-                Err(_) => {
-                    println!("Failed to deserialize message payload: {{ (index . 1).multiple_messages_enum.unique_id }}\nOriginal message: {:#?}", message);
-                    // TODO: Handle the failed deserialization here
-                },
-            }
-        {{else}}
-        {{ range (index . 1).messages }}
-        match serde_json::from_slice::<{{ .unique_id }}>(&message.message.payload.as_ref()) {
-            Ok(deserialized_message) => {
-                println!("Received message {:#?}", deserialized_message);
-                // TODO: Replace this with your own handler code
-                {{ if .payload}}
-                {{ if .payload.multiple_payload_enum}}
-                    // TODO: this is always None for now (unreachable),
-                    // take a look the comment in src/template_model/simplified_operation.rs/simplify_schema
-                    match deserialized_message.payload {
-                        {{$enumName := .payload.multiple_payload_enum.unique_id}}
-                        {{ range .payload.multiple_payload_enum.messages }}
-                            {{ $enumName }}::{{ .unique_id }}(payload) => {
-                            println!("Received message payload {{ .unique_id }}", payload);
-                            }   
-                        {{ end }}
+        {{ if (index . 1).original_operation.bindings.nats.streamname }}
+            pub fn stream_handler_{{ (index . 1).unique_id }}(message: jetstream::Message) {
+                {{ if (index . 1).multiple_messages_enum }}
+                    match serde_json::from_slice::<{{ (index . 1).multiple_messages_enum.unique_id }}>(&message.message.payload.as_ref()) {
+                        Ok(deserialized_message) => {
+                            // TODO: Replace this with your own handler code
+                            println!("Received message {:#?}", deserialized_message);
+                        },
+                        Err(_) => {
+                            println!("Failed to deserialize message payload: {{ (index . 1).multiple_messages_enum.unique_id }}\nOriginal message: {:#?}", message);
+                            // TODO: Handle the failed deserialization here
+                        },
                     }
+                {{else}}
+                    {{ range (index . 1).messages }}
+                        match serde_json::from_slice::<{{ .unique_id }}>(&message.message.payload.as_ref()) {
+                            Ok(deserialized_message) => {
+                                println!("Received message {:#?}", deserialized_message);
+                                // TODO: Replace this with your own handler code
+                                {{ if .payload}}
+                                    {{ if .payload.multiple_payload_enum}}
+                                        // TODO: this is always None for now (unreachable),
+                                        // take a look the comment in src/template_model/simplified_operation.rs/simplify_schema
+                                        match deserialized_message.payload {
+                                            {{$enumName := .payload.multiple_payload_enum.unique_id}}
+                                            {{ range .payload.multiple_payload_enum.messages }}
+                                                {{ $enumName }}::{{ .unique_id }}(payload) => {
+                                                println!("Received message payload {{ .unique_id }}", payload);
+                                                }   
+                                            {{ end }}
+                                        }
+                                    {{ end }}
+                                {{ end }}
+                            },
+                            Err(_) => {
+                                println!("Failed to deserialize message payload: {{ .unique_id }}\nOriginal message: {:#?}", message);
+                                // TODO: Handle the failed deserialization here
+                            },
+                        }
+                    {{ end }}
                 {{ end }}
+            }
+        
+    
+        {{else}}
+            pub fn handler_{{ (index . 1).unique_id }}(message: Message) {
+                {{ if (index . 1).multiple_messages_enum }}
+                    match serde_json::from_slice::<{{ (index . 1).multiple_messages_enum.unique_id }}>(&message.payload.as_ref()) {
+                        Ok(deserialized_message) => {
+                            // TODO: Replace this with your own handler code
+                            println!("Received message {:#?}", deserialized_message);
+                        },
+                        Err(_) => {
+                            println!("Failed to deserialize message payload: {{ (index . 1).multiple_messages_enum.unique_id }}\nOriginal message: {:#?}", message);
+                            // TODO: Handle the failed deserialization here
+                        },
+                    }
+                {{else}}
+                    {{ range (index . 1).messages }}
+                        match serde_json::from_slice::<{{ .unique_id }}>(&message.payload.as_ref()) {
+                            Ok(deserialized_message) => {
+                                println!("Received message {:#?}", deserialized_message);
+                                // TODO: Replace this with your own handler code
+                                {{ if .payload}}
+                                    {{ if .payload.multiple_payload_enum}}
+                                        // TODO: this is always None for now (unreachable),
+                                        // take a look the comment in src/template_model/simplified_operation.rs/simplify_schema
+                                        match deserialized_message.payload {
+                                            {{$enumName := .payload.multiple_payload_enum.unique_id}}
+                                            {{ range .payload.multiple_payload_enum.messages }}
+                                                {{ $enumName }}::{{ .unique_id }}(payload) => {
+                                                println!("Received message payload {{ .unique_id }}", payload);
+                                                }   
+                                            {{ end }}
+                                        }
+                                    {{ end }}
+                                {{ end }}
+                            },
+                            Err(_) => {
+                                println!("Failed to deserialize message payload: {{ .unique_id }}\nOriginal message: {:#?}", message);
+                                // TODO: Handle the failed deserialization here
+                            },
+                        }
+                    {{ end }}
                 {{ end }}
-            },
-            Err(_) => {
-                println!("Failed to deserialize message payload: {{ .unique_id }}\nOriginal message: {:#?}", message);
-                // TODO: Handle the failed deserialization here
-            },
-        }
-        {{ end }}
-        {{ end }}
-        {{ end }}
-    }
+            }
+        {{end}}
     {{else}}
     pub fn handler_{{ (index . 1).unique_id }}(message: Message) {
         {{ if (index . 1).multiple_messages_enum }}
@@ -87,35 +131,36 @@ use std::time;
                 },
             }
         {{else}}
-        {{ range (index . 1).messages }}
-        match serde_json::from_slice::<{{ .unique_id }}>(&message.payload.as_ref()) {
-            Ok(deserialized_message) => {
-                println!("Received message {:#?}", deserialized_message);
-                // TODO: Replace this with your own handler code
-                {{ if .payload}}
-                {{ if .payload.multiple_payload_enum}}
-                    // TODO: this is always None for now (unreachable),
-                    // take a look the comment in src/template_model/simplified_operation.rs/simplify_schema
-                    match deserialized_message.payload {
-                        {{$enumName := .payload.multiple_payload_enum.unique_id}}
-                        {{ range .payload.multiple_payload_enum.messages }}
-                            {{ $enumName }}::{{ .unique_id }}(payload) => {
-                            println!("Received message payload {{ .unique_id }}", payload);
-                            }   
+            {{ range (index . 1).messages }}
+                match serde_json::from_slice::<{{ .unique_id }}>(&message.payload.as_ref()) {
+                    Ok(deserialized_message) => {
+                        println!("Received message {:#?}", deserialized_message);
+                        // TODO: Replace this with your own handler code
+                        {{ if .payload}}
+                            {{ if .payload.multiple_payload_enum}}
+                                // TODO: this is always None for now (unreachable),
+                                // take a look the comment in src/template_model/simplified_operation.rs/simplify_schema
+                                match deserialized_message.payload {
+                                    {{$enumName := .payload.multiple_payload_enum.unique_id}}
+                                    {{ range .payload.multiple_payload_enum.messages }}
+                                        {{ $enumName }}::{{ .unique_id }}(payload) => {
+                                        println!("Received message payload {{ .unique_id }}", payload);
+                                        }   
+                                    {{ end }}
+                                }
+                            {{ end }}
                         {{ end }}
-                    }
-                {{ end }}
-                {{ end }}
-            },
-            Err(_) => {
-                println!("Failed to deserialize message payload: {{ .unique_id }}\nOriginal message: {:#?}", message);
-                // TODO: Handle the failed deserialization here
-            },
-        }
-        {{ end }}
+                    },
+                    Err(_) => {
+                        println!("Failed to deserialize message payload: {{ .unique_id }}\nOriginal message: {:#?}", message);
+                        // TODO: Handle the failed deserialization here
+                    },
+                }
+            {{ end }}
         {{ end }}
     }
-    {{end}}
+    {{ end }}
+
 {{ end  }}
 
 {{ range .subscribe_channels }}
@@ -125,26 +170,35 @@ use std::time;
     ///     {{ .unique_id }}
     /// {{ end }}
     {{ if (index . 1).original_operation.bindings }}
-    {{ if (index . 1).original_operation.bindings.nats.streamname }}
-    pub async fn stream_producer_{{ (index . 1).unique_id }}(context_stream: &Context, channel: &str) { //context instead of client
-        // This is just an example producer, publishing a message every 2 seconds
-        // TODO: replace this with your own producer code
-        loop {
-            tokio::time::sleep(time::Duration::from_secs(2)).await;
-            stream_publish_message(context_stream, channel, "{\"test\":\"serialized\"}").await;
+        {{ if (index . 1).original_operation.bindings.nats.streamname }}
+            pub async fn stream_producer_{{ (index . 1).unique_id }}(context_stream: &Context, channel: &str) { //context instead of client
+                // This is just an example producer, publishing a message every 2 seconds
+                // TODO: replace this with your own producer code
+                loop {
+                    tokio::time::sleep(time::Duration::from_secs(2)).await;
+                    stream_publish_message(context_stream, channel, "{\"test\":\"serialized\"}").await;
+                }
+            }
+        {{else}}
+            pub async fn producer_{{ (index . 1).unique_id }}(client: &Client, channel: &str) {
+                // This is just an example producer, publishing a message every 2 seconds
+                // TODO: replace this with your own producer code
+                loop {
+                    tokio::time::sleep(time::Duration::from_secs(2)).await;
+                    publish_message(client, channel, "{\"test\":\"serialized\"}").await;
+                }
+            }
+        {{end}}
+    {{ else }}
+        pub async fn producer_{{ (index . 1).unique_id }}(client: &Client, channel: &str) {
+            // This is just an example producer, publishing a message every 2 seconds
+            // TODO: replace this with your own producer code
+            loop {
+                tokio::time::sleep(time::Duration::from_secs(2)).await;
+                publish_message(client, channel, "{\"test\":\"serialized\"}").await;
+            }
         }
-    }
-    {{else}}
-    pub async fn producer_{{ (index . 1).unique_id }}(client: &Client, channel: &str) {
-        // This is just an example producer, publishing a message every 2 seconds
-        // TODO: replace this with your own producer code
-        loop {
-            tokio::time::sleep(time::Duration::from_secs(2)).await;
-            publish_message(client, channel, "{\"test\":\"serialized\"}").await;
-        }
-    }
-    {{end}}
-    {{end}}
+    {{ end }}
 {{ end  }}
 
 

--- a/templates/handler.go
+++ b/templates/handler.go
@@ -2,8 +2,10 @@ use async_nats::{Client, Message, jetstream};
 use async_nats::jetstream::Context;
 use crate::{publish_message,
 {{ range .subscribe_channels }}
+{{ if (index . 1).original_operation.bindings }}
 {{ if (index . 1).original_operation.bindings.nats.streamname }}
     stream_publish_message,
+ {{ end }}   
 {{end}}
 {{end}}
 {{ range .model.messages }}
@@ -27,6 +29,7 @@ use std::time;
     /// {{ range (index . 1).messages }}
     ///     {{ .unique_id }}
     /// {{ end }}
+    {{ if (index . 1).original_operation.bindings }}
     {{ if (index . 1).original_operation.bindings.nats.streamname }}
     pub fn stream_handler_{{ (index . 1).unique_id }}(message: jetstream::Message) {
         {{ if (index . 1).multiple_messages_enum }}
@@ -66,6 +69,7 @@ use std::time;
                 // TODO: Handle the failed deserialization here
             },
         }
+        {{ end }}
         {{ end }}
         {{ end }}
     }
@@ -120,6 +124,7 @@ use std::time;
     /// {{ range (index . 1).messages }}
     ///     {{ .unique_id }}
     /// {{ end }}
+    {{ if (index . 1).original_operation.bindings }}
     {{ if (index . 1).original_operation.bindings.nats.streamname }}
     pub async fn stream_producer_{{ (index . 1).unique_id }}(context_stream: &Context, channel: &str) { //context instead of client
         // This is just an example producer, publishing a message every 2 seconds
@@ -138,6 +143,7 @@ use std::time;
             publish_message(client, channel, "{\"test\":\"serialized\"}").await;
         }
     }
+    {{end}}
     {{end}}
 {{ end  }}
 

--- a/templates/main.go
+++ b/templates/main.go
@@ -84,13 +84,14 @@ async fn main() -> Result<(), async_nats::Error> {
                 {{ if (index . 1).original_operation.bindings.nats.queue }}
                     let mut {{ (index . 1).unique_id }} = client.queue_subscribe("{{ index . 0  }}".into(), "{{ (index . 1).original_operation.bindings.nats.queue }}".into()).await?;
                 {{ else  }}
-                    let context_jetstream = jetstream::new(client);
+                    let clientcpy = client.clone();
+                    let context_jetstream = jetstream::new(clientcpy);
                     let {{ (index . 1).unique_id }} = "{{ (index . 1).original_operation.bindings.nats.streamname }}";
                     let consumer = get_consumer(&context_jetstream, &{{ (index . 1).unique_id }}).await?;
                 {{end}}
-            {{ else }}
-                let mut {{ (index . 1).unique_id }} = client.subscribe("{{ index . 0  }}".into()).await?;
-            {{end}}
+        {{ else }}
+            let mut {{ (index . 1).unique_id }} = client.subscribe("{{ index . 0  }}".into()).await?;
+        {{end}}
     {{end}}
 
     //test(&client, "foo").await;
@@ -98,26 +99,28 @@ async fn main() -> Result<(), async_nats::Error> {
     tokio::join!(
     {{ range .subscribe_channels }}
         {{ if (index . 1).original_operation.bindings }}
-             {{if (index . 1).original_operation.bindings.nats.streamname}}
-        stream_producer_{{ (index . 1).unique_id }}(&context_jetstream, "{{ (index . 1).original_operation.bindings.nats.streamname }}"),
-             {{ end }}
-        {{ else }}
-        producer_{{ (index . 1).unique_id }}(&client, "{{ index . 0  }}"),
+            {{if (index . 1).original_operation.bindings.nats.streamname}}
+                stream_producer_{{ (index . 1).unique_id }}(&context_jetstream, "{{ (index . 1).original_operation.bindings.nats.streamname }}"),
+            {{ else }}
+                producer_{{ (index . 1).unique_id }}(&client, "{{ index . 0  }}"),
             {{ end }}
+        {{ else }}
+            producer_{{ (index . 1).unique_id }}(&client, "{{ index . 0  }}"),
+        {{ end }}
     {{ end  }}
     {{ range .publish_channels  }}
         {{ if (index . 1).original_operation.bindings }}
-        {{if (index . 1).original_operation.bindings.nats.streamname}}
-        stream_listen_for_message(&consumer, stream_handler_{{ (index . 1).unique_id }}),
+            {{if (index . 1).original_operation.bindings.nats.streamname}}
+                stream_listen_for_message(&consumer, stream_handler_{{ (index . 1).unique_id }}),
+
+            {{ else }}
+                listen_for_message(&mut  {{ (index . 1).unique_id }}, handler_{{ (index . 1).unique_id }}),
+            {{ end }}
 
         {{ else }}
-        listen_for_message(&mut  {{ (index . 1).unique_id }}, handler_{{ (index . 1).unique_id }}),
+            listen_for_message(&mut  {{ (index . 1).unique_id }}, handler_{{ (index . 1).unique_id }}),
         {{ end }}
-
-        {{ else }}
-        listen_for_message(&mut  {{ (index . 1).unique_id }}, handler_{{ (index . 1).unique_id }}),
-        {{end}}
-    {{  end  }}
+    {{ end }}
     );
 
     println!("fin");

--- a/templates/main.go
+++ b/templates/main.go
@@ -1,7 +1,9 @@
 mod handler;
 mod model;
 use async_nats::{Client, Message, Subscriber};
-
+use async_nats::jetstream::{self, Context, stream};
+use async_nats::jetstream::consumer::{pull::{self, Config}, Consumer};
+use std::time::Duration;
 use futures::StreamExt;
 
 use crate::handler::*;
@@ -23,27 +25,83 @@ async fn publish_message(client: &Client, channel: &str, payload: &str) {
     println!("sent");
 }
 
+pub async fn get_consumer(jetstream: &Context, stream_name: &str) -> Result<Consumer<Config>, async_nats::Error>{
+
+    let stream = jetstream.get_or_create_stream(jetstream::stream::Config {
+        name: stream_name.to_string(),
+        ..Default::default()
+    }).await?;
+    let consumer = stream.get_or_create_consumer("consumer", Config {
+        durable_name: Some("consumer".to_string()),
+        ..Default::default()
+    }).await?;
+    return Ok(consumer);
+}
+
+{{ range .subscribe_channels }}
+{{ if (index . 1).original_operation.bindings.nats.streamname }}
+async fn stream_publish_message(client: &Context, channel: &str, payload: &str) {
+    let owned_payload = payload.to_owned().into(); // Convert to Bytes
+    client
+        .publish(channel.to_string(), owned_payload)
+        .await
+        .unwrap();
+    println!("sent");
+}
+{{end}}
+{{end}} //supports only one stream, otherwise no unique function name(one function is enough for any number of streams, but you have to check if there is one)
+
+
+{{range .publish_channels}}
+{{ if (index . 1).original_operation.bindings.nats.streamname }}
+async fn stream_listen_for_message(sub: &Consumer<Config>, handler: impl Fn(jetstream::Message)) -> Result<(), async_nats::Error>{
+    loop{
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+        let mut messages = sub.messages().await?.take(10);
+        while let Some(message) = messages.next().await {
+            let message = message?;
+            handler(message);
+            println!("Message received by Subscriber: {:?}", sub.cached_info().name); // if you show sub its a mess, is now a Context
+        }
+    }
+    Ok(())
+}
+{{end}}
+{{end}}
+
 #[tokio::main]
 async fn main() -> Result<(), async_nats::Error> {
     let client = async_nats::connect("{{ .server.url }}").await?;
 
     {{ range .publish_channels }}
-    {{ if (index . 1).original_operation.bindings }}
+    {{ if (index . 1).original_operation.bindings.nats.queue }}
         let mut {{ (index . 1).unique_id }} = client.queue_subscribe("{{ index . 0  }}".into(), "{{ (index . 1).original_operation.bindings.nats.queue }}".into()).await?;
        
+    {{ else if (index . 1).original_operation.bindings.nats.streamname }}
+        let context_jetstream = jetstream::new(client);
+        let {{ (index . 1).unique_id }} = "{{ (index . 1).original_operation.bindings.nats.streamname }}";
+        let consumer = get_consumer(&context_jetstream, &{{ (index . 1).unique_id }}).await?;
     {{ else }}
         let mut {{ (index . 1).unique_id }} = client.subscribe("{{ index . 0  }}".into()).await?;
     {{end}}
     {{end}}
 
-    test(&client, "foo").await;
+    //test(&client, "foo").await;
 
     tokio::join!(
     {{ range .subscribe_channels }}
+        {{if (index . 1).original_operation.bindings.nats.streamname}}
+        stream_producer_{{ (index . 1).unique_id }}(&context_jetstream, "{{ (index . 1).original_operation.bindings.nats.streamname }}"),
+        {{ else }}
         producer_{{ (index . 1).unique_id }}(&client, "{{ index . 0  }}"),
+        {{ end }}
     {{ end  }}
     {{ range .publish_channels  }}
+        {{if (index . 1).original_operation.bindings.nats.streamname}}
+        stream_listen_for_message(&consumer, stream_handler_{{ (index . 1).unique_id }}),
+        {{ else }}
         listen_for_message(&mut  {{ (index . 1).unique_id }}, handler_{{ (index . 1).unique_id }}),
+        {{end}}
     {{  end  }}
     );
 


### PR DESCRIPTION
- template supports one stream now
- added example spec-files for a stream example and an example for mixing nats functions
- formatted template some more
- more streams can be supported, if the stream_publish and stream_listen functions are generated without checking if necessary 