### PR TITLE
added warp server on tokio task

### DIFF
--- a/templates/Cargo.toml.go
+++ b/templates/Cargo.toml.go
@@ -17,3 +17,5 @@ opentelemetry = { version = "*", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "*", features = ["rt-tokio", "isahc_collector_client"] }
 log = "0.4.0"
 env_logger = "0.10.0"
+cargo_metadata = "0.15.4"
+warp = "0.3.5"

--- a/templates/src/main.rs.go
+++ b/templates/src/main.rs.go
@@ -1,7 +1,8 @@
 mod handler;
 mod model;
 mod utils;
-mod cli; 
+mod cli;
+mod warp_server;
 use clap::Parser;
 use crate::cli::*;
 use utils::*;
@@ -15,6 +16,8 @@ mod logger;
 
 #[tokio::main]
 async fn main() -> Result<(), async_nats::Error> {
+    //start warp server
+    tokio::spawn(warp_server::server());
     // Load .env file
     let env: HashMap<String,String> = config::get_env();
 

--- a/templates/src/warp_server.rs.go
+++ b/templates/src/warp_server.rs.go
@@ -20,11 +20,7 @@ async fn metamessage() -> Result<impl warp::Reply, warp::Rejection>{
         .unwrap();
 
     let root = meta.root_package().unwrap();
-    //let option = root.metadata["my"]["option"].as_str().unwrap();
-    //let version = &root.version;
-
-    //println!("sent root metadata");
-    let root =  serde_json::to_string(&root).unwrap();
+    let root = serde_json::to_string(&root).unwrap();
     Ok(root)
 }
 

--- a/templates/src/warp_server.rs.go
+++ b/templates/src/warp_server.rs.go
@@ -1,0 +1,52 @@
+use cargo_metadata::MetadataCommand;
+use warp::Filter;
+use serde_json;
+
+async fn life() -> Result<impl warp::Reply, warp::Rejection> {
+    Ok(format!("alive\n"))
+}
+
+async fn ready_func() -> Result<impl warp::Reply, warp::Rejection> {
+    //TODO: actually check if service is ready
+    Ok(format!("ready\n"))
+}
+
+async fn metamessage() -> Result<impl warp::Reply, warp::Rejection>{
+    let path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    let meta = MetadataCommand::new()
+        .manifest_path("./Cargo.toml")
+        .current_dir(&path)
+        .exec()
+        .unwrap();
+
+    let root = meta.root_package().unwrap();
+    //let option = root.metadata["my"]["option"].as_str().unwrap();
+    //let version = &root.version;
+
+    //println!("sent root metadata");
+    let root =  serde_json::to_string(&root).unwrap();
+    Ok(root)
+}
+
+pub async fn server() {
+
+    let metadata = warp::get()
+        .and(warp::path("root"))
+        .and(warp::path::end())
+        .and_then(metamessage);
+
+
+    let liveness = warp::get()
+        .and(warp::path("healthz"))
+        .and(warp::path::end())
+        .and_then(life);
+
+    let readiness = warp::get()
+        .and(warp::path("readyz"))
+        .and(warp::path::end())
+        .and_then(ready_func);
+
+    warp::serve(liveness.or(readiness).or(metadata))
+        .run(([127, 0, 0, 1], 8000))
+        .await;
+}


### PR DESCRIPTION
- server listens on port 8000 by default
- as long as the server runs /healthz always answers alive
- readiness is not really defined yet, difficult doing so without final microservice