### PR TITLE
Remove default spec path from CLI

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 pub struct Args {
     // Add a positional argument that the user has to supply:
     /// The specification file to parse      
-    #[arg(short, long, default_value = "./example/specs/basic.yaml")]
+    #[arg(short, long)]
     pub specification: String,
 
     /// The output directory


### PR DESCRIPTION
When the user is actually using our CLI, they don't have the whole project, so they need to provide an input spec.

When using the cloned project, there's still the `just run` command, which specifies an example spec as a default param.

<img width="471" alt="image" src="https://github.com/Programmierpraktikum-MVA/AsyncAPI/assets/18115394/1fdf89d8-4cb6-48a8-bdda-de639ab0ba51">
